### PR TITLE
go back to aiohttp3.6.0 i remember dependa bot showing..

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 discord.py==1.5.0
-aiohttp==3.6.2
+aiohttp==3.6.0
 asyncpg==0.21.0
 aiofiles==0.5.0


### PR DESCRIPTION
so depends bot showed 3.6.2 was 62% percent incompatible when i updated the dependencies so I will go back and see if its better for compatibility