### PR TITLE
Create joinmsg log everytime a user joins a server

### DIFF
--- a/events/command_error.py
+++ b/events/command_error.py
@@ -68,7 +68,6 @@ class Commanderror(commands.Cog):
 def setup(bot):
     try:
         bot.add_cog(Commanderror(bot))
-        bot.logging.info("Loaded event CommandError")
-    except Exception:
-        bot.logging.error("Error loading event CommandError")
+        bot.logger.info("Loaded event CommandError")
+
     

--- a/events/joinlog/on_member_join.py
+++ b/events/joinlog/on_member_join.py
@@ -33,6 +33,12 @@ class Greetmsg(commands.Cog):
 
                 embed.add_footer(name="Member Count:", value=f{guild.members})
 
+                try:
+                    await logch.send(embed)
+                    except Exception:
+                        pass
+
+
                 
 def setup(bot):
     bot.add_cog(Greetmsg(bot))

--- a/events/joinlog/on_member_join.py
+++ b/events/joinlog/on_member_join.py
@@ -11,7 +11,7 @@ class Greetmsg(commands.Cog):
     async def on_member_join(self, member):
         if self.bot.db.execute("SELECT logging_join FROM guild_settings WHERE id = ?"):
             usedinvite = Noneg
-            joinchan = self.bot.db.execute("SELECT logging_join FROM guild_settings WHERE id = ?")
+            logch = self.bot.db.execute("SELECT logging_join FROM guild_settings WHERE id = ?")
 
             vars  = {
                 '{user.mention}': member.mention,
@@ -21,7 +21,7 @@ class Greetmsg(commands.Cog):
         
 
         
-            if joinchan:
+            if logch:
                 embed =  discord.Embed(title="Member Joined", url="https://tenor.com/view/penguin-hello-hi-hey-there-cutie-gif-3950966")
 
                 embed.set_author(name=f"{member}", icon_url=str(
@@ -29,7 +29,9 @@ class Greetmsg(commands.Cog):
 
                 embed.add_field(name='Account Created', value=datetime.datetime.utcnow() - member.created_at) + 'ago', inline=False)
                 if used invite:
-                    embed.add_field(name="Invite used", value=used_invite, inline=False)
+                    embed.add_field(name="Invite used:", value=used_invite, inline=False)
+
+                embed.add_footer(name="Member Count:", value=f{guild.members})
 
                 
 def setup(bot):

--- a/events/joinlog/on_member_join.py
+++ b/events/joinlog/on_member_join.py
@@ -9,11 +9,29 @@ class Greetmsg(commands.Cog):
     
     @commands.Cog.listener()
     async def on_member_join(self, member):
-        if self.bot.db.execute("SELECT logging_leave FROM guild_settings WHERE id = ?"):
-            joinchan = self.bot.db("SELECT ")
+        if self.bot.db.execute("SELECT logging_join FROM guild_settings WHERE id = ?"):
+            usedinvite = Noneg
+            joinchan = self.bot.db.execute("SELECT logging_join FROM guild_settings WHERE id = ?")
+
+            vars  = {
+                '{user.mention}': member.mention,
+                '{user}': str(member),
+                '{user.name}': member.name,
+            }   '{count}': str(member.guild.member_count)
         
 
+        
+            if joinchan:
+                embed =  discord.Embed(title="Member Joined", url="https://tenor.com/view/penguin-hello-hi-hey-there-cutie-gif-3950966")
 
+                embed.set_author(name=f"{member}", icon_url=str(
+                    member.avatar_url_as(static_format='png', size=2048)))
+
+                embed.add_field(name='Account Created', value=datetime.datetime.utcnow() - member.created_at) + 'ago', inline=False)
+                if used invite:
+                    embed.add_field(name="Invite used", value=used_invite, inline=False)
+
+                
 def setup(bot):
     bot.add_cog(Greetmsg(bot))
     bot.logger.info("Event Loaded Greetmsg!")


### PR DESCRIPTION
First off, this can be toggled on an off this is not in the mod log/action log category so you can easily turn this log off so it doesn't clutter other  logs (and assign to different channels..) But it's very simple and just sends the member's icon the new servers member count and when they're account was created anyways @TheCodingGuru lmk what you think 