### PR TITLE
Finish chunking #49

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -34,7 +34,7 @@ import dotenv
 import os
 from os.path import join, dirname
 from dotenv import load_dotenv
-from secrets import token
+
 
 
 dotenv_path = join(dirname(__file__), 'config.env')
@@ -42,7 +42,7 @@ load_dotenv(dotenv_path)
 
 POSTGRES_PASSWORD = os.environ.get("database_password")
 DATABASE = os.environ.get('database')
-#token = os.environ.get('discord_token')
+token = os.environ.get('discord_token')
 #intents = discord.Intents()
 #intents.value = 1607
 

--- a/events/ready.py
+++ b/events/ready.py
@@ -19,6 +19,17 @@ class Ready(commands.Cog):
         self.bot.logging.info(f"Guilds: {len(self.bot.guilds)}")
         self.bot.logging.info(f"Users: {len(self.bot.users)}")
         
+        # Im not sure why but dpy discards member updates (e.g if they update nickname etc etc) Ffrom memebers that arent cached so i need them to be cached for updates and features
+        # note: Features like logging will continue to work as normal when members are cached.
+        [await self.chunk(g) for g in sorted(self.bot.guilds, key=lambda g: g.member_count, reverse=True) if self.bot.should_chunk(g)]
+        async def chunk(self, guild):
+            try:
+                guild.chunk()
+            except Exception:
+                self.bot.logging.error(
+                    f"Failed to chunk guilds {guild}"
+                )
+        
         
 def setup(bot):
     bot.add_cog(Ready(bot))

--- a/tests/testinvite.py
+++ b/tests/testinvite.py
@@ -1,4 +1,4 @@
 import unittest
 import unittest.mock
-import .command
+import . command from .
 from .command import invite


### PR DESCRIPTION
Alright, I finally got to chunking guilds @TheCodingGuru do you mind reviewing this before I merge/ you merge it LGTM to me but I just wanted to see what you think.

Also, the reason why I'm needing to chunk guilds/members is that dpy discards member updates (so if a member bans a user changes some thing) it won't update which means I need every single user cached so the features will work normally with logging (user action logs, etc)  and member updates