### PR TITLE
Fix token being displayed in bot.py

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -71,4 +71,4 @@ for files in os.listdir('./command'):
         bot.load_extension(f'command.{files[:-3]}')
         bot.load_extension
 
-bot.run('NzkwMzk5MzgxODQwMDY4NjE5.X-ACyQ.ZGyMam5wpeAMUK_KV-wemMCZdmM')
+bot.run(f"{token}")


### PR DESCRIPTION
I don't know if this was just an example, but I noticed you have an .env key for a discord token but was providing one in bot.run, so I went ahead and removed it to use the .env key.